### PR TITLE
Support Statement.closeOnCompletion.

### DIFF
--- a/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
+++ b/src/main/java/org/tarantool/jdbc/SQLDatabaseMetadata.java
@@ -1126,8 +1126,8 @@ public class SQLDatabaseMetadata implements DatabaseMetaData {
         return new SQLNullResultSet(SQLResultHolder.ofQuery(meta, rows), createMetadataStatement());
     }
 
-    private SQLStatement createMetadataStatement() throws SQLException {
-        return connection.createStatement().unwrap(SQLStatement.class);
+    private TarantoolStatement createMetadataStatement() throws SQLException {
+        return connection.createStatement().unwrap(TarantoolStatement.class);
     }
 
     private static <T> T ensureType(Class<T> cls, Object v) throws Exception {
@@ -1152,7 +1152,7 @@ public class SQLDatabaseMetadata implements DatabaseMetaData {
 
     protected class SQLNullResultSet extends SQLResultSet {
 
-        public SQLNullResultSet(SQLResultHolder holder, SQLStatement ownerStatement) throws SQLException {
+        public SQLNullResultSet(SQLResultHolder holder, TarantoolStatement ownerStatement) throws SQLException {
             super(holder, ownerStatement);
         }
 

--- a/src/main/java/org/tarantool/jdbc/TarantoolStatement.java
+++ b/src/main/java/org/tarantool/jdbc/TarantoolStatement.java
@@ -1,0 +1,30 @@
+package org.tarantool.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Tarantool specific statement extensions.
+ */
+public interface TarantoolStatement extends Statement {
+
+    /**
+     * Checks for statement completion and closes itself,
+     * according to {@link Statement#closeOnCompletion()}.
+     */
+    void checkCompletion() throws SQLException;
+
+    /**
+     * Returns {@link ResultSet} which will be initialized by <code>data</code>.
+     *
+     * @param data predefined result to be wrapped by {@link ResultSet}
+     *
+     * @return wrapped result
+     *
+     * @throws SQLException if a database access error occurs or
+     *                      this method is called on a closed <code>Statement</code>
+     */
+    ResultSet executeMetadata(SQLResultHolder data) throws SQLException;
+
+}

--- a/src/test/java/org/tarantool/TarantoolConnectionSQLOpsIT.java
+++ b/src/test/java/org/tarantool/TarantoolConnectionSQLOpsIT.java
@@ -22,7 +22,9 @@ public class TarantoolConnectionSQLOpsIT extends AbstractTarantoolSQLOpsIT {
 
     @AfterEach
     public void tearDown() {
-        connection.close();
+        if (connection != null) {
+            connection.close();
+        }
     }
 
     @Override

--- a/src/test/java/org/tarantool/jdbc/JdbcConnectionTimeoutIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcConnectionTimeoutIT.java
@@ -3,9 +3,12 @@ package org.tarantool.jdbc;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.tarantool.TestAssumptions.assumeMinimalServerVersion;
 import static org.tarantool.TestUtils.makeInstanceEnv;
 
+import org.tarantool.ServerVersion;
 import org.tarantool.TarantoolClientConfig;
+import org.tarantool.TarantoolConsole;
 import org.tarantool.TarantoolControl;
 import org.tarantool.protocol.TarantoolPacket;
 
@@ -25,6 +28,7 @@ import java.util.Properties;
 public class JdbcConnectionTimeoutIT {
 
     protected static final String LUA_FILE = "jdk-testing.lua";
+    private static final String HOST = "localhost";
     protected static final int LISTEN = 3301;
     protected static final int ADMIN = 3313;
     private static final String INSTANCE_NAME = "jdk-testing";
@@ -47,6 +51,7 @@ public class JdbcConnectionTimeoutIT {
 
     @BeforeEach
     void setUp() throws SQLException {
+        assumeMinimalServerVersion(TarantoolConsole.open(HOST, ADMIN), ServerVersion.V_2_1);
         connection = new SQLConnection("", new Properties()) {
             @Override
             protected SQLTarantoolClientImpl makeSqlClient(String address, TarantoolClientConfig config) {
@@ -66,7 +71,9 @@ public class JdbcConnectionTimeoutIT {
 
     @AfterEach
     void tearDown() throws SQLException {
-        connection.close();
+        if (connection != null) {
+            connection.close();
+        }
     }
 
     @Test

--- a/src/test/java/org/tarantool/jdbc/JdbcResultSetIT.java
+++ b/src/test/java/org/tarantool/jdbc/JdbcResultSetIT.java
@@ -167,8 +167,12 @@ public class JdbcResultSetIT extends JdbcTypesIT {
         assertNotNull(resultSet);
         ResultSetMetaData metaData = resultSet.getMetaData();
         assertNotNull(metaData);
+
+        int expectedColumnSize = 2;
+        assertEquals(expectedColumnSize, metaData.getColumnCount());
+
         resultSet.close();
-        assertEquals(metaData, resultSet.getMetaData());
+        assertEquals(expectedColumnSize, metaData.getColumnCount());
     }
 
     @Test

--- a/src/test/java/org/tarantool/jdbc/ds/JdbcDataSourceIT.java
+++ b/src/test/java/org/tarantool/jdbc/ds/JdbcDataSourceIT.java
@@ -7,12 +7,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.tarantool.TestAssumptions.assumeMinimalServerVersion;
 import static org.tarantool.TestUtils.makeInstanceEnv;
 
+import org.tarantool.ServerVersion;
+import org.tarantool.TarantoolConsole;
 import org.tarantool.TarantoolControl;
 import org.tarantool.jdbc.SQLProperty;
 
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.ThrowingSupplier;
@@ -27,23 +31,28 @@ import javax.sql.DataSource;
 class JdbcDataSourceIT {
 
     private static final String LUA_FILE = "jdk-testing.lua";
+    private static final String HOST = "localhost";
     private static final int LISTEN = 3301;
     private static final int ADMIN = 3313;
     private static final String INSTANCE_NAME = "data-source-testing";
 
     private SQLDataSource dataSource;
 
-    @BeforeEach
-    void setUp() {
+    @BeforeAll
+    static void setUpEnv() {
         TarantoolControl control = new TarantoolControl();
         control.createInstance(INSTANCE_NAME, LUA_FILE, makeInstanceEnv(LISTEN, ADMIN));
         control.start(INSTANCE_NAME);
+    }
 
+    @BeforeEach
+    void setUp() {
+        assumeMinimalServerVersion(TarantoolConsole.open(HOST, ADMIN), ServerVersion.V_2_1);
         dataSource = new SQLDataSource();
     }
 
-    @AfterEach
-    void tearDown() {
+    @AfterAll
+    static void tearDownEnv() {
         TarantoolControl control = new TarantoolControl();
         control.stop(INSTANCE_NAME);
     }


### PR DESCRIPTION
Check a statement after all its dependent result set are closed.

Extract TarantoolStatement as tarantool specific extension interface to
be used for internal purposes (incompatible vendor API).

Closes: #180